### PR TITLE
remove guava dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,10 +41,6 @@
       <artifactId>slf4j-nop</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-    </dependency>
-    <dependency>
       <groupId>${project.parent.groupId}</groupId>
       <artifactId>standard-test-dependencies</artifactId>
       <version>${project.parent.version}</version>

--- a/src/main/java/uk/org/lidalia/slf4jext/ConventionalLevelHierarchy.java
+++ b/src/main/java/uk/org/lidalia/slf4jext/ConventionalLevelHierarchy.java
@@ -1,13 +1,14 @@
 package uk.org.lidalia.slf4jext;
 
-import com.google.common.collect.ImmutableSet;
-
-import static com.google.common.collect.Sets.immutableEnumSet;
 import static uk.org.lidalia.slf4jext.Level.DEBUG;
 import static uk.org.lidalia.slf4jext.Level.ERROR;
 import static uk.org.lidalia.slf4jext.Level.INFO;
 import static uk.org.lidalia.slf4jext.Level.TRACE;
 import static uk.org.lidalia.slf4jext.Level.WARN;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Set;
 
 /**
  * The conventional hierarchical notion of Levels, where info being enabled implies warn and error being enabled, is not a
@@ -20,42 +21,42 @@ public final class ConventionalLevelHierarchy {
      *
      * An empty set.
      */
-    public static final ImmutableSet<Level> OFF_LEVELS = ImmutableSet.of();
+    public static final Set<Level> OFF_LEVELS = Collections.emptySet();
 
     /**
      * Levels that would be considered enabled in Log4J/Logback if a Logger was set to ERROR.
      *
      * A set containing {@link Level#ERROR}.
      */
-    public static final ImmutableSet<Level> ERROR_LEVELS = immutableEnumSet(ERROR);
+    public static final Set<Level> ERROR_LEVELS = Collections.unmodifiableSet(EnumSet.of(ERROR));
 
     /**
      * Levels that would be considered enabled in Log4J/Logback if a Logger was set to WARN.
      *
      * A set containing {@link Level#ERROR} and {@link Level#WARN}.
      */
-    public static final ImmutableSet<Level> WARN_LEVELS = immutableEnumSet(ERROR, WARN);
+    public static final Set<Level> WARN_LEVELS = Collections.unmodifiableSet(EnumSet.of(ERROR, WARN));
 
     /**
      * Levels that would be considered enabled in Log4J/Logback if a Logger was set to INFO.
      *
      * A set containing {@link Level#ERROR}, {@link Level#WARN} and {@link Level#INFO}.
      */
-    public static final ImmutableSet<Level> INFO_LEVELS = immutableEnumSet(ERROR, WARN, INFO);
+    public static final Set<Level> INFO_LEVELS = Collections.unmodifiableSet(EnumSet.of(ERROR, WARN, INFO));
 
     /**
      * Levels that would be considered enabled in Log4J/Logback if a Logger was set to DEBUG.
      *
      * A set containing {@link Level#ERROR}, {@link Level#WARN}, {@link Level#INFO} and {@link Level#DEBUG}.
      */
-    public static final ImmutableSet<Level> DEBUG_LEVELS = immutableEnumSet(ERROR, WARN, INFO, DEBUG);
+    public static final Set<Level> DEBUG_LEVELS = Collections.unmodifiableSet(EnumSet.of(ERROR, WARN, INFO, DEBUG));
 
     /**
      * Levels that would be considered enabled in Log4J/Logback if a Logger was set to TRACE.
      *
      * A set containing {@link Level#ERROR}, {@link Level#WARN}, {@link Level#INFO}, {@link Level#DEBUG} and {@link Level#TRACE}.
      */
-    public static final ImmutableSet<Level> TRACE_LEVELS = immutableEnumSet(ERROR, WARN, INFO, DEBUG, TRACE);
+    public static final Set<Level> TRACE_LEVELS = Collections.unmodifiableSet(EnumSet.of(ERROR, WARN, INFO, DEBUG, TRACE));
 
     private ConventionalLevelHierarchy() {
         throw new UnsupportedOperationException("Not instantiable");

--- a/src/main/java/uk/org/lidalia/slf4jext/Level.java
+++ b/src/main/java/uk/org/lidalia/slf4jext/Level.java
@@ -1,14 +1,11 @@
 package uk.org.lidalia.slf4jext;
 
-import com.google.common.collect.ImmutableSet;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Set;
+
 import org.slf4j.Logger;
 import org.slf4j.Marker;
-
-import java.util.HashSet;
-
-import static com.google.common.collect.Sets.immutableEnumSet;
-import static com.google.common.collect.Sets.newHashSet;
-import static java.util.Arrays.asList;
 
 /**
  * Enum modelling the logical levels implied by the way <a href="http://www.slf4j.org">SLF4J</a> has the same set of methods
@@ -321,8 +318,8 @@ public enum Level {
         }
     };
 
-    private static final ImmutableSet<Level> ALL_LEVELS = immutableEnumSet(asList(values()));
-    private static final ImmutableSet<Level> ENABLABLE_LEVELS = makeEnablabeValues();
+    private static final Set<Level> ALL_LEVELS = Collections.unmodifiableSet(EnumSet.allOf(Level.class));
+    private static final Set<Level> ENABLABLE_LEVELS = Collections.unmodifiableSet(makeEnablabeValues());
 
     abstract boolean isEnabled(Logger logger);
 
@@ -351,20 +348,20 @@ public enum Level {
     /**
      * @return an ImmutableSet containing the constants of this enum type
      */
-    public static ImmutableSet<Level> valueSet() {
+    public static Set<Level> valueSet() {
         return ALL_LEVELS;
     }
 
     /**
      * @return an ImmutableSet containing the constants of this enum type other than OFF
      */
-    public static ImmutableSet<Level> enablableValueSet() {
+    public static Set<Level> enablableValueSet() {
         return ENABLABLE_LEVELS;
     }
 
-    private static ImmutableSet<Level> makeEnablabeValues() {
-        final HashSet<Level> levels = newHashSet(values());
-        levels.remove(OFF);
-        return immutableEnumSet(levels);
+    private static Set<Level> makeEnablabeValues() {
+        EnumSet<Level> enabled = EnumSet.allOf(Level.class);
+        enabled.remove(OFF);
+        return enabled;
     }
 }

--- a/src/test/java/uk/org/lidalia/slf4jutils/LevelTests.java
+++ b/src/test/java/uk/org/lidalia/slf4jutils/LevelTests.java
@@ -1,21 +1,19 @@
 package uk.org.lidalia.slf4jutils;
 
-import java.util.Set;
-
-import org.junit.Test;
-
-import com.google.common.collect.ImmutableSet;
-
-import uk.org.lidalia.slf4jext.Level;
-
-import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static uk.org.lidalia.slf4jext.Level.DEBUG;
 import static uk.org.lidalia.slf4jext.Level.ERROR;
 import static uk.org.lidalia.slf4jext.Level.INFO;
 import static uk.org.lidalia.slf4jext.Level.TRACE;
 import static uk.org.lidalia.slf4jext.Level.WARN;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+import org.junit.Test;
+
+import uk.org.lidalia.slf4jext.Level;
 
 public class LevelTests {
 
@@ -32,7 +30,7 @@ public class LevelTests {
 
     @Test
     public void enablableValueSetContains() {
-        assertThat(Level.enablableValueSet(), is(ImmutableSet.of(ERROR, WARN, INFO, DEBUG, TRACE)));
+        assertTrue(Level.enablableValueSet().equals(EnumSet.of(ERROR, WARN, INFO, DEBUG, TRACE)));
     }
 
     @Test(expected = UnsupportedOperationException.class)

--- a/src/test/java/uk/org/lidalia/slf4jutils/LoggerTests.java
+++ b/src/test/java/uk/org/lidalia/slf4jutils/LoggerTests.java
@@ -1,25 +1,9 @@
 package uk.org.lidalia.slf4jutils;
 
-import com.google.common.base.Function;
-import com.google.common.collect.Lists;
-import junitparams.JUnitParamsRunner;
-import junitparams.Parameters;
-
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.slf4j.Marker;
-
-import java.lang.reflect.Method;
-import java.util.List;
-
-import uk.org.lidalia.slf4jext.Logger;
-
-import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.powermock.api.mockito.PowerMockito.mock;
@@ -30,6 +14,17 @@ import static uk.org.lidalia.slf4jext.Level.OFF;
 import static uk.org.lidalia.slf4jext.Level.TRACE;
 import static uk.org.lidalia.slf4jext.Level.WARN;
 import static uk.org.lidalia.test.Values.uniqueValueFor;
+
+import java.lang.reflect.Method;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.slf4j.Marker;
+
+import uk.org.lidalia.slf4jext.Logger;
 
 @RunWith(JUnitParamsRunner.class)
 public class LoggerTests {
@@ -585,11 +580,10 @@ public class LoggerTests {
 
     private Object[] buildParamsFor(Method loggerMethod) throws Exception {
         Class<?>[] parameterTypes = loggerMethod.getParameterTypes();
-        List<Object> params = Lists.transform(asList(parameterTypes), new Function<Class<?>, Object>() {
-            public Object apply(Class<?> aClass) {
-                return uniqueValueFor(aClass);
-            }
-        });
-        return params.toArray();
+        Object[] uniqueValues = new Object[parameterTypes.length];
+        for (int i = 0; i < uniqueValues.length; i++) {
+            uniqueValues[i] = uniqueValueFor(parameterTypes[i]);
+        }
+        return uniqueValues;
     }
 }


### PR DESCRIPTION
Hi Robert,

I searched for code to dynamically choose slf4j's log level and came to your project which looks really nice.
I am building a small CDI interceptor lib at the moment which could be built on that basis.

Personally I do like Google guava a lot, but do not want to require the users of that generic library to include guava in their artefacts. Because of that I replaced `ImmutableSet` by `EnumSet` in combination with `Collections.unmodifiableSet` in my fork.
The code can be read almost as good as before and behaves strictly the same.

Maybe other users would prefer the reduced dependencies, too. :-)

PS: This is my first pull request, so if there is anything missing or wrong please do not hesitate to tell me about it.
